### PR TITLE
Changes from CoreNeuron benchmark branch

### DIFF
--- a/cells/TCR_template.hoc
+++ b/cells/TCR_template.hoc
@@ -924,7 +924,7 @@ func type() {return       12 }
        gbar_kahp_slower =   0 // 5.E-05
        insert cal
        gbar_cal =   0.0005
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0005
        insert ar
        gbar_ar =   0.00025
@@ -953,7 +953,7 @@ func type() {return       12 }
        gbar_kahp_slower =   0 // 5.E-05
        insert cal
        gbar_cal =   0.0005
-       insert cat
+       insert traub_cat
        gbar_cat =   0.005
        insert ar
        gbar_ar =   0.0005
@@ -980,7 +980,7 @@ func type() {return       12 }
        gbar_kahp_slower =   0 // 5.E-05
        insert cal
        gbar_cal =   0.00025
-       insert cat
+       insert traub_cat
        gbar_cat =   0.003
        insert ar
        gbar_ar =   0.0003
@@ -1007,7 +1007,7 @@ func type() {return       12 }
        gbar_kahp_slower =   0 // 5.E-05
        insert cal
        gbar_cal =   0.00025
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0005
        insert ar
        gbar_ar =   0.0003

--- a/cells/TCR_template.hoc
+++ b/cells/TCR_template.hoc
@@ -922,7 +922,7 @@ func type() {return       12 }
        gbar_k2 =   0.002
        insert kahp_slower
        gbar_kahp_slower =   0 // 5.E-05
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0005
        insert traub_cat
        gbar_cat =   0.0005
@@ -951,7 +951,7 @@ func type() {return       12 }
        gbar_k2 =   0.002
        insert kahp_slower
        gbar_kahp_slower =   0 // 5.E-05
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0005
        insert traub_cat
        gbar_cat =   0.005
@@ -978,7 +978,7 @@ func type() {return       12 }
        gbar_k2 =   0.002
        insert kahp_slower
        gbar_kahp_slower =   0 // 5.E-05
-       insert cal
+       insert traub_cal
        gbar_cal =   0.00025
        insert traub_cat
        gbar_cat =   0.003
@@ -1005,7 +1005,7 @@ func type() {return       12 }
        gbar_k2 =   0.002
        insert kahp_slower
        gbar_kahp_slower =   0 // 5.E-05
-       insert cal
+       insert traub_cal
        gbar_cal =   0.00025
        insert traub_cat
        gbar_cat =   0.0005

--- a/cells/deepLTS_template.hoc
+++ b/cells/deepLTS_template.hoc
@@ -314,7 +314,7 @@ func type() {return   11 }
        gbar_k2 =   0.0005
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0001
        insert cat_a
        gbar_cat_a =   5.E-05
@@ -343,7 +343,7 @@ func type() {return   11 }
        gbar_k2 =   0.0005
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0001
        insert cat_a
        gbar_cat_a =   5.E-05
@@ -372,7 +372,7 @@ func type() {return   11 }
        gbar_k2 =   0.0005
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0001
        insert cat_a
        gbar_cat_a =   5.E-05
@@ -401,7 +401,7 @@ func type() {return   11 }
        gbar_k2 =   0.0005
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0002
        insert cat_a
        gbar_cat_a =   0.002
@@ -430,7 +430,7 @@ func type() {return   11 }
        gbar_k2 =   0.0005
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0002
        insert cat_a
        gbar_cat_a =   0.002
@@ -459,7 +459,7 @@ func type() {return   11 }
        gbar_k2 =   0.0005
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0002
        insert cat_a
        gbar_cat_a =   0.002
@@ -488,7 +488,7 @@ func type() {return   11 }
        gbar_k2 =   0.0005
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0002
        insert cat_a
        gbar_cat_a =   0.002
@@ -517,7 +517,7 @@ func type() {return   11 }
        gbar_k2 =   0.0005
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0002
        insert cat_a
        gbar_cat_a =   0.002
@@ -546,7 +546,7 @@ func type() {return   11 }
        gbar_k2 =   0.0005
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0002
        insert cat_a
        gbar_cat_a =   0.002

--- a/cells/deepaxax_template.hoc
+++ b/cells/deepaxax_template.hoc
@@ -435,7 +435,7 @@ func type() {return  10 }
        gbar_kahp_slower =   0.0001
        insert cal
        gbar_cal =   0.0001
-       insert cat
+       insert traub_cat
        gbar_cat =   5.E-05
        insert ar
        gbar_ar =   2.5E-05
@@ -464,7 +464,7 @@ func type() {return  10 }
        gbar_kahp_slower =   0.0001
        insert cal
        gbar_cal =   0.0001
-       insert cat
+       insert traub_cat
        gbar_cat =   5.E-05
        insert ar
        gbar_ar =   2.5E-05
@@ -493,7 +493,7 @@ func type() {return  10 }
        gbar_kahp_slower =   0.0001
        insert cal
        gbar_cal =   0.0001
-       insert cat
+       insert traub_cat
        gbar_cat =   5.E-05
        insert ar
        gbar_ar =   2.5E-05
@@ -522,7 +522,7 @@ func type() {return  10 }
        gbar_kahp_slower =   0.0001
        insert cal
        gbar_cal =   0.0002
-       insert cat
+       insert traub_cat
        gbar_cat =   0.002
        insert ar
        gbar_ar =   2.5E-05
@@ -551,7 +551,7 @@ func type() {return  10 }
        gbar_kahp_slower =   0.0001
        insert cal
        gbar_cal =   0.0002
-       insert cat
+       insert traub_cat
        gbar_cat =   0.002
        insert ar
        gbar_ar =   2.5E-05
@@ -580,7 +580,7 @@ func type() {return  10 }
        gbar_kahp_slower =   0.0001
        insert cal
        gbar_cal =   0.0002
-       insert cat
+       insert traub_cat
        gbar_cat =   0.002
        insert ar
        gbar_ar =   2.5E-05
@@ -609,7 +609,7 @@ func type() {return  10 }
        gbar_kahp_slower =   0.0001
        insert cal
        gbar_cal =   0.0002
-       insert cat
+       insert traub_cat
        gbar_cat =   0.002
        insert ar
        gbar_ar =   2.5E-05
@@ -638,7 +638,7 @@ func type() {return  10 }
        gbar_kahp_slower =   0.0001
        insert cal
        gbar_cal =   0.0002
-       insert cat
+       insert traub_cat
        gbar_cat =   0.002
        insert ar
        gbar_ar =   2.5E-05
@@ -667,7 +667,7 @@ func type() {return  10 }
        gbar_kahp_slower =   0.0001
        insert cal
        gbar_cal =   0.0002
-       insert cat
+       insert traub_cat
        gbar_cat =   0.002
        insert ar
        gbar_ar =   2.5E-05

--- a/cells/deepaxax_template.hoc
+++ b/cells/deepaxax_template.hoc
@@ -433,7 +433,7 @@ func type() {return  10 }
        gbar_k2 =   0.0005
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0001
        insert traub_cat
        gbar_cat =   5.E-05
@@ -462,7 +462,7 @@ func type() {return  10 }
        gbar_k2 =   0.0005
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0001
        insert traub_cat
        gbar_cat =   5.E-05
@@ -491,7 +491,7 @@ func type() {return  10 }
        gbar_k2 =   0.0005
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0001
        insert traub_cat
        gbar_cat =   5.E-05
@@ -520,7 +520,7 @@ func type() {return  10 }
        gbar_k2 =   0.0005
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0002
        insert traub_cat
        gbar_cat =   0.002
@@ -549,7 +549,7 @@ func type() {return  10 }
        gbar_k2 =   0.0005
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0002
        insert traub_cat
        gbar_cat =   0.002
@@ -578,7 +578,7 @@ func type() {return  10 }
        gbar_k2 =   0.0005
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0002
        insert traub_cat
        gbar_cat =   0.002
@@ -607,7 +607,7 @@ func type() {return  10 }
        gbar_k2 =   0.0005
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0002
        insert traub_cat
        gbar_cat =   0.002
@@ -636,7 +636,7 @@ func type() {return  10 }
        gbar_k2 =   0.0005
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0002
        insert traub_cat
        gbar_cat =   0.002
@@ -665,7 +665,7 @@ func type() {return  10 }
        gbar_k2 =   0.0005
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0002
        insert traub_cat
        gbar_cat =   0.002

--- a/cells/deepbask_template.hoc
+++ b/cells/deepbask_template.hoc
@@ -376,7 +376,7 @@ func type() {return  9 }
        gbar_kahp_slower =   0.0001
        insert cal
        gbar_cal =   0.0001
-       insert cat
+       insert traub_cat
        gbar_cat =   5.E-05
        insert ar
        gbar_ar =   2.5E-05
@@ -405,7 +405,7 @@ func type() {return  9 }
        gbar_kahp_slower =   0.0001
        insert cal
        gbar_cal =   0.0001
-       insert cat
+       insert traub_cat
        gbar_cat =   5.E-05
        insert ar
        gbar_ar =   2.5E-05
@@ -434,7 +434,7 @@ func type() {return  9 }
        gbar_kahp_slower =   0.0001
        insert cal
        gbar_cal =   0.0001
-       insert cat
+       insert traub_cat
        gbar_cat =   5.E-05
        insert ar
        gbar_ar =   2.5E-05
@@ -463,7 +463,7 @@ func type() {return  9 }
        gbar_kahp_slower =   0.0001
        insert cal
        gbar_cal =   0.0002
-       insert cat
+       insert traub_cat
        gbar_cat =   0.002
        insert ar
        gbar_ar =   2.5E-05
@@ -492,7 +492,7 @@ func type() {return  9 }
        gbar_kahp_slower =   0.0001
        insert cal
        gbar_cal =   0.0002
-       insert cat
+       insert traub_cat
        gbar_cat =   0.002
        insert ar
        gbar_ar =   2.5E-05
@@ -521,7 +521,7 @@ func type() {return  9 }
        gbar_kahp_slower =   0.0001
        insert cal
        gbar_cal =   0.0002
-       insert cat
+       insert traub_cat
        gbar_cat =   0.002
        insert ar
        gbar_ar =   2.5E-05
@@ -550,7 +550,7 @@ func type() {return  9 }
        gbar_kahp_slower =   0.0001
        insert cal
        gbar_cal =   0.0002
-       insert cat
+       insert traub_cat
        gbar_cat =   0.002
        insert ar
        gbar_ar =   2.5E-05
@@ -579,7 +579,7 @@ func type() {return  9 }
        gbar_kahp_slower =   0.0001
        insert cal
        gbar_cal =   0.0002
-       insert cat
+       insert traub_cat
        gbar_cat =   0.002
        insert ar
        gbar_ar =   2.5E-05
@@ -608,7 +608,7 @@ func type() {return  9 }
        gbar_kahp_slower =   0.0001
        insert cal
        gbar_cal =   0.0002
-       insert cat
+       insert traub_cat
        gbar_cat =   0.002
        insert ar
        gbar_ar =   2.5E-05

--- a/cells/deepbask_template.hoc
+++ b/cells/deepbask_template.hoc
@@ -374,7 +374,7 @@ func type() {return  9 }
        gbar_k2 =   0.0005
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0001
        insert traub_cat
        gbar_cat =   5.E-05
@@ -403,7 +403,7 @@ func type() {return  9 }
        gbar_k2 =   0.0005
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0001
        insert traub_cat
        gbar_cat =   5.E-05
@@ -432,7 +432,7 @@ func type() {return  9 }
        gbar_k2 =   0.0005
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0001
        insert traub_cat
        gbar_cat =   5.E-05
@@ -461,7 +461,7 @@ func type() {return  9 }
        gbar_k2 =   0.0005
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0002
        insert traub_cat
        gbar_cat =   0.002
@@ -490,7 +490,7 @@ func type() {return  9 }
        gbar_k2 =   0.0005
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0002
        insert traub_cat
        gbar_cat =   0.002
@@ -519,7 +519,7 @@ func type() {return  9 }
        gbar_k2 =   0.0005
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0002
        insert traub_cat
        gbar_cat =   0.002
@@ -548,7 +548,7 @@ func type() {return  9 }
        gbar_k2 =   0.0005
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0002
        insert traub_cat
        gbar_cat =   0.002
@@ -577,7 +577,7 @@ func type() {return  9 }
        gbar_k2 =   0.0005
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0002
        insert traub_cat
        gbar_cat =   0.002
@@ -606,7 +606,7 @@ func type() {return  9 }
        gbar_k2 =   0.0005
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0002
        insert traub_cat
        gbar_cat =   0.002

--- a/cells/nRT_template.hoc
+++ b/cells/nRT_template.hoc
@@ -315,7 +315,7 @@ func type() {return       13 }
        gbar_k2 =   0.0005
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0005
        insert cat_a
        gbar_cat_a =   5.E-05
@@ -344,7 +344,7 @@ func type() {return       13 }
        gbar_k2 =   0.0005
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0005
        insert cat_a
        gbar_cat_a =   5.E-05
@@ -373,7 +373,7 @@ func type() {return       13 }
        gbar_k2 =   0.0005
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0005
        insert cat_a
        gbar_cat_a =   5.E-05
@@ -402,7 +402,7 @@ func type() {return       13 }
        gbar_k2 =   0.0005
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0005
        insert cat_a
        gbar_cat_a =   0.002
@@ -431,7 +431,7 @@ func type() {return       13 }
        gbar_k2 =   0.0005
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0005
        insert cat_a
        gbar_cat_a =   0.002
@@ -460,7 +460,7 @@ func type() {return       13 }
        gbar_k2 =   0.0005
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0005
        insert cat_a
        gbar_cat_a =   0.002
@@ -489,7 +489,7 @@ func type() {return       13 }
        gbar_k2 =   0.0005
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0005
        insert cat_a
        gbar_cat_a =   0.002
@@ -518,7 +518,7 @@ func type() {return       13 }
        gbar_k2 =   0.0005
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0005
        insert cat_a
        gbar_cat_a =   0.002
@@ -547,7 +547,7 @@ func type() {return       13 }
        gbar_k2 =   0.0005
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0005
        insert cat_a
        gbar_cat_a =   0.002

--- a/cells/nontuftRS_template.hoc
+++ b/cells/nontuftRS_template.hoc
@@ -339,7 +339,7 @@ func type() {return 8 }
        gbar_k2 =   0.0001
        insert kahp_deeppyr
        gbar_kahp_deeppyr =   0.0002
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0002
        insert traub_cat
        gbar_cat =   0.0001
@@ -368,7 +368,7 @@ func type() {return 8 }
        gbar_k2 =   0.0001
        insert kahp_deeppyr
        gbar_kahp_deeppyr =   0.0002
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0002
        insert traub_cat
        gbar_cat =   0.0001
@@ -393,7 +393,7 @@ func type() {return 8 }
        gbar_k2 =   0.0001
        insert kahp_deeppyr
        gbar_kahp_deeppyr =   0.0002
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0002
        insert traub_cat
        gbar_cat =   0.0001
@@ -418,7 +418,7 @@ func type() {return 8 }
        gbar_k2 =   0.0001
        insert kahp_deeppyr
        gbar_kahp_deeppyr =   0.0002
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0002
        insert traub_cat
        gbar_cat =   0.0001
@@ -447,7 +447,7 @@ func type() {return 8 }
        gbar_k2 =   0.0001
        insert kahp_deeppyr
        gbar_kahp_deeppyr =   0.0002
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0002
        insert traub_cat
        gbar_cat =   0.0001
@@ -476,7 +476,7 @@ func type() {return 8 }
        gbar_k2 =   0.0001
        insert kahp_deeppyr
        gbar_kahp_deeppyr =   0.0002
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0002
        insert traub_cat
        gbar_cat =   0.0001
@@ -501,7 +501,7 @@ func type() {return 8 }
        gbar_k2 =   0.0001
        insert kahp_deeppyr
        gbar_kahp_deeppyr =   0.0002
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0002
        insert traub_cat
        gbar_cat =   0.0001
@@ -526,7 +526,7 @@ func type() {return 8 }
        gbar_k2 =   0.0001
        insert kahp_deeppyr
        gbar_kahp_deeppyr =   0.0002
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0002
        insert traub_cat
        gbar_cat =   0.0001
@@ -551,7 +551,7 @@ func type() {return 8 }
        gbar_k2 =   0.0001
        insert kahp_deeppyr
        gbar_kahp_deeppyr =   0.0002
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0002
        insert traub_cat
        gbar_cat =   0.0001
@@ -576,7 +576,7 @@ func type() {return 8 }
        gbar_k2 =   0.0001
        insert kahp_deeppyr
        gbar_kahp_deeppyr =   0.0002
-       insert cal
+       insert traub_cal
        gbar_cal =   0.002
        insert traub_cat
        gbar_cat =   0.0001
@@ -601,7 +601,7 @@ func type() {return 8 }
        gbar_k2 =   0.0001
        insert kahp_deeppyr
        gbar_kahp_deeppyr =   0.0002
-       insert cal
+       insert traub_cal
        gbar_cal =   0.002
        insert traub_cat
        gbar_cat =   0.0001
@@ -626,7 +626,7 @@ func type() {return 8 }
        gbar_k2 =   0.0001
        insert kahp_deeppyr
        gbar_kahp_deeppyr =   0.0002
-       insert cal
+       insert traub_cal
        gbar_cal =   0.002
        insert traub_cat
        gbar_cat =   0.0001
@@ -651,7 +651,7 @@ func type() {return 8 }
        gbar_k2 =   0.0001
        insert kahp_deeppyr
        gbar_kahp_deeppyr =   0.0002
-       insert cal
+       insert traub_cal
        gbar_cal =   0.002
        insert traub_cat
        gbar_cat =   0.0001
@@ -676,7 +676,7 @@ func type() {return 8 }
        gbar_k2 =   0.0001
        insert kahp_deeppyr
        gbar_kahp_deeppyr =   0.0002
-       insert cal
+       insert traub_cal
        gbar_cal =   0.002
        insert traub_cat
        gbar_cat =   0.0001

--- a/cells/nontuftRS_template.hoc
+++ b/cells/nontuftRS_template.hoc
@@ -341,7 +341,7 @@ func type() {return 8 }
        gbar_kahp_deeppyr =   0.0002
        insert cal
        gbar_cal =   0.0002
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.00025
@@ -370,7 +370,7 @@ func type() {return 8 }
        gbar_kahp_deeppyr =   0.0002
        insert cal
        gbar_cal =   0.0002
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.00025
@@ -395,7 +395,7 @@ func type() {return 8 }
        gbar_kahp_deeppyr =   0.0002
        insert cal
        gbar_cal =   0.0002
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.00025
@@ -420,7 +420,7 @@ func type() {return 8 }
        gbar_kahp_deeppyr =   0.0002
        insert cal
        gbar_cal =   0.0002
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.00025
@@ -449,7 +449,7 @@ func type() {return 8 }
        gbar_kahp_deeppyr =   0.0002
        insert cal
        gbar_cal =   0.0002
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.00025
@@ -478,7 +478,7 @@ func type() {return 8 }
        gbar_kahp_deeppyr =   0.0002
        insert cal
        gbar_cal =   0.0002
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.00025
@@ -503,7 +503,7 @@ func type() {return 8 }
        gbar_kahp_deeppyr =   0.0002
        insert cal
        gbar_cal =   0.0002
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.00025
@@ -528,7 +528,7 @@ func type() {return 8 }
        gbar_kahp_deeppyr =   0.0002
        insert cal
        gbar_cal =   0.0002
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.00025
@@ -553,7 +553,7 @@ func type() {return 8 }
        gbar_kahp_deeppyr =   0.0002
        insert cal
        gbar_cal =   0.0002
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.00025
@@ -578,7 +578,7 @@ func type() {return 8 }
        gbar_kahp_deeppyr =   0.0002
        insert cal
        gbar_cal =   0.002
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.00025
@@ -603,7 +603,7 @@ func type() {return 8 }
        gbar_kahp_deeppyr =   0.0002
        insert cal
        gbar_cal =   0.002
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.00025
@@ -628,7 +628,7 @@ func type() {return 8 }
        gbar_kahp_deeppyr =   0.0002
        insert cal
        gbar_cal =   0.002
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.00025
@@ -653,7 +653,7 @@ func type() {return 8 }
        gbar_kahp_deeppyr =   0.0002
        insert cal
        gbar_cal =   0.002
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.00025
@@ -678,7 +678,7 @@ func type() {return 8 }
        gbar_kahp_deeppyr =   0.0002
        insert cal
        gbar_cal =   0.002
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.00025

--- a/cells/spinstell_template.hoc
+++ b/cells/spinstell_template.hoc
@@ -315,7 +315,7 @@ func type() {return 5 }
        gbar_k2 =   0.0001
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0005
        insert cat_a
        gbar_cat_a =   0.0001
@@ -344,7 +344,7 @@ func type() {return 5 }
        gbar_k2 =   0.0001
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0005
        insert cat_a
        gbar_cat_a =   0.0001
@@ -373,7 +373,7 @@ func type() {return 5 }
        gbar_k2 =   0.0001
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0005
        insert cat_a
        gbar_cat_a =   0.0001
@@ -400,7 +400,7 @@ func type() {return 5 }
        gbar_k2 =   0.0001
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0005
        insert cat_a
        gbar_cat_a =   0.0001
@@ -425,7 +425,7 @@ func type() {return 5 }
        gbar_k2 =   0.0001
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0005
        insert cat_a
        gbar_cat_a =   0.0001
@@ -450,7 +450,7 @@ func type() {return 5 }
        gbar_k2 =   0.0001
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0005
        insert cat_a
        gbar_cat_a =   0.0001
@@ -475,7 +475,7 @@ func type() {return 5 }
        gbar_k2 =   0.0001
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.003
        insert cat_a
        gbar_cat_a =   0.0001
@@ -500,7 +500,7 @@ func type() {return 5 }
        gbar_k2 =   0.0001
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.003
        insert cat_a
        gbar_cat_a =   0.0001
@@ -525,7 +525,7 @@ func type() {return 5 }
        gbar_k2 =   0.0001
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.003
        insert cat_a
        gbar_cat_a =   0.0001

--- a/cells/supLTS_template.hoc
+++ b/cells/supLTS_template.hoc
@@ -314,7 +314,7 @@ func type() {return    4 }
        gbar_k2 =   0.0005
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0001
        insert cat_a
        gbar_cat_a =   5.E-05
@@ -343,7 +343,7 @@ func type() {return    4 }
        gbar_k2 =   0.0005
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0001
        insert cat_a
        gbar_cat_a =   5.E-05
@@ -372,7 +372,7 @@ func type() {return    4 }
        gbar_k2 =   0.0005
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0001
        insert cat_a
        gbar_cat_a =   5.E-05
@@ -401,7 +401,7 @@ func type() {return    4 }
        gbar_k2 =   0.0005
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0002
        insert cat_a
        gbar_cat_a =   0.002
@@ -430,7 +430,7 @@ func type() {return    4 }
        gbar_k2 =   0.0005
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0002
        insert cat_a
        gbar_cat_a =   0.002
@@ -459,7 +459,7 @@ func type() {return    4 }
        gbar_k2 =   0.0005
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0002
        insert cat_a
        gbar_cat_a =   0.002
@@ -488,7 +488,7 @@ func type() {return    4 }
        gbar_k2 =   0.0005
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0002
        insert cat_a
        gbar_cat_a =   0.002
@@ -517,7 +517,7 @@ func type() {return    4 }
        gbar_k2 =   0.0005
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0002
        insert cat_a
        gbar_cat_a =   0.002
@@ -546,7 +546,7 @@ func type() {return    4 }
        gbar_k2 =   0.0005
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0002
        insert cat_a
        gbar_cat_a =   0.002

--- a/cells/supaxax_template.hoc
+++ b/cells/supaxax_template.hoc
@@ -316,7 +316,7 @@ func type() {return   3 }
        gbar_kahp_slower =   0.0001
        insert cal
        gbar_cal =   0.0001
-       insert cat
+       insert traub_cat
        gbar_cat =   5.E-05
        insert ar
        gbar_ar =   2.5E-05
@@ -345,7 +345,7 @@ func type() {return   3 }
        gbar_kahp_slower =   0.0001
        insert cal
        gbar_cal =   0.0001
-       insert cat
+       insert traub_cat
        gbar_cat =   5.E-05
        insert ar
        gbar_ar =   2.5E-05
@@ -374,7 +374,7 @@ func type() {return   3 }
        gbar_kahp_slower =   0.0001
        insert cal
        gbar_cal =   0.0001
-       insert cat
+       insert traub_cat
        gbar_cat =   5.E-05
        insert ar
        gbar_ar =   2.5E-05
@@ -403,7 +403,7 @@ func type() {return   3 }
        gbar_kahp_slower =   0.0001
        insert cal
        gbar_cal =   0.0002
-       insert cat
+       insert traub_cat
        gbar_cat =   0.002
        insert ar
        gbar_ar =   2.5E-05
@@ -432,7 +432,7 @@ func type() {return   3 }
        gbar_kahp_slower =   0.0001
        insert cal
        gbar_cal =   0.0002
-       insert cat
+       insert traub_cat
        gbar_cat =   0.002
        insert ar
        gbar_ar =   2.5E-05
@@ -461,7 +461,7 @@ func type() {return   3 }
        gbar_kahp_slower =   0.0001
        insert cal
        gbar_cal =   0.0002
-       insert cat
+       insert traub_cat
        gbar_cat =   0.002
        insert ar
        gbar_ar =   2.5E-05
@@ -490,7 +490,7 @@ func type() {return   3 }
        gbar_kahp_slower =   0.0001
        insert cal
        gbar_cal =   0.0002
-       insert cat
+       insert traub_cat
        gbar_cat =   0.002
        insert ar
        gbar_ar =   2.5E-05
@@ -519,7 +519,7 @@ func type() {return   3 }
        gbar_kahp_slower =   0.0001
        insert cal
        gbar_cal =   0.0002
-       insert cat
+       insert traub_cat
        gbar_cat =   0.002
        insert ar
        gbar_ar =   2.5E-05
@@ -548,7 +548,7 @@ func type() {return   3 }
        gbar_kahp_slower =   0.0001
        insert cal
        gbar_cal =   0.0002
-       insert cat
+       insert traub_cat
        gbar_cat =   0.002
        insert ar
        gbar_ar =   2.5E-05

--- a/cells/supaxax_template.hoc
+++ b/cells/supaxax_template.hoc
@@ -314,7 +314,7 @@ func type() {return   3 }
        gbar_k2 =   0.0005
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0001
        insert traub_cat
        gbar_cat =   5.E-05
@@ -343,7 +343,7 @@ func type() {return   3 }
        gbar_k2 =   0.0005
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0001
        insert traub_cat
        gbar_cat =   5.E-05
@@ -372,7 +372,7 @@ func type() {return   3 }
        gbar_k2 =   0.0005
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0001
        insert traub_cat
        gbar_cat =   5.E-05
@@ -401,7 +401,7 @@ func type() {return   3 }
        gbar_k2 =   0.0005
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0002
        insert traub_cat
        gbar_cat =   0.002
@@ -430,7 +430,7 @@ func type() {return   3 }
        gbar_k2 =   0.0005
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0002
        insert traub_cat
        gbar_cat =   0.002
@@ -459,7 +459,7 @@ func type() {return   3 }
        gbar_k2 =   0.0005
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0002
        insert traub_cat
        gbar_cat =   0.002
@@ -488,7 +488,7 @@ func type() {return   3 }
        gbar_k2 =   0.0005
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0002
        insert traub_cat
        gbar_cat =   0.002
@@ -517,7 +517,7 @@ func type() {return   3 }
        gbar_k2 =   0.0005
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0002
        insert traub_cat
        gbar_cat =   0.002
@@ -546,7 +546,7 @@ func type() {return   3 }
        gbar_k2 =   0.0005
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0002
        insert traub_cat
        gbar_cat =   0.002

--- a/cells/supbask_template.hoc
+++ b/cells/supbask_template.hoc
@@ -314,7 +314,7 @@ func type() {return   2 }
        gbar_k2 =   0.0005
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0001
        insert traub_cat
        gbar_cat =   5.E-05
@@ -343,7 +343,7 @@ func type() {return   2 }
        gbar_k2 =   0.0005
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0001
        insert traub_cat
        gbar_cat =   5.E-05
@@ -372,7 +372,7 @@ func type() {return   2 }
        gbar_k2 =   0.0005
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0001
        insert traub_cat
        gbar_cat =   5.E-05
@@ -401,7 +401,7 @@ func type() {return   2 }
        gbar_k2 =   0.0005
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0002
        insert traub_cat
        gbar_cat =   0.002
@@ -430,7 +430,7 @@ func type() {return   2 }
        gbar_k2 =   0.0005
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0002
        insert traub_cat
        gbar_cat =   0.002
@@ -459,7 +459,7 @@ func type() {return   2 }
        gbar_k2 =   0.0005
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0002
        insert traub_cat
        gbar_cat =   0.002
@@ -488,7 +488,7 @@ func type() {return   2 }
        gbar_k2 =   0.0005
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0002
        insert traub_cat
        gbar_cat =   0.002
@@ -517,7 +517,7 @@ func type() {return   2 }
        gbar_k2 =   0.0005
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0002
        insert traub_cat
        gbar_cat =   0.002
@@ -546,7 +546,7 @@ func type() {return   2 }
        gbar_k2 =   0.0005
        insert kahp_slower
        gbar_kahp_slower =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0002
        insert traub_cat
        gbar_cat =   0.002

--- a/cells/supbask_template.hoc
+++ b/cells/supbask_template.hoc
@@ -316,7 +316,7 @@ func type() {return   2 }
        gbar_kahp_slower =   0.0001
        insert cal
        gbar_cal =   0.0001
-       insert cat
+       insert traub_cat
        gbar_cat =   5.E-05
        insert ar
        gbar_ar =   2.5E-05
@@ -345,7 +345,7 @@ func type() {return   2 }
        gbar_kahp_slower =   0.0001
        insert cal
        gbar_cal =   0.0001
-       insert cat
+       insert traub_cat
        gbar_cat =   5.E-05
        insert ar
        gbar_ar =   2.5E-05
@@ -374,7 +374,7 @@ func type() {return   2 }
        gbar_kahp_slower =   0.0001
        insert cal
        gbar_cal =   0.0001
-       insert cat
+       insert traub_cat
        gbar_cat =   5.E-05
        insert ar
        gbar_ar =   2.5E-05
@@ -403,7 +403,7 @@ func type() {return   2 }
        gbar_kahp_slower =   0.0001
        insert cal
        gbar_cal =   0.0002
-       insert cat
+       insert traub_cat
        gbar_cat =   0.002
        insert ar
        gbar_ar =   2.5E-05
@@ -432,7 +432,7 @@ func type() {return   2 }
        gbar_kahp_slower =   0.0001
        insert cal
        gbar_cal =   0.0002
-       insert cat
+       insert traub_cat
        gbar_cat =   0.002
        insert ar
        gbar_ar =   2.5E-05
@@ -461,7 +461,7 @@ func type() {return   2 }
        gbar_kahp_slower =   0.0001
        insert cal
        gbar_cal =   0.0002
-       insert cat
+       insert traub_cat
        gbar_cat =   0.002
        insert ar
        gbar_ar =   2.5E-05
@@ -490,7 +490,7 @@ func type() {return   2 }
        gbar_kahp_slower =   0.0001
        insert cal
        gbar_cal =   0.0002
-       insert cat
+       insert traub_cat
        gbar_cat =   0.002
        insert ar
        gbar_ar =   2.5E-05
@@ -519,7 +519,7 @@ func type() {return   2 }
        gbar_kahp_slower =   0.0001
        insert cal
        gbar_cal =   0.0002
-       insert cat
+       insert traub_cat
        gbar_cat =   0.002
        insert ar
        gbar_ar =   2.5E-05
@@ -548,7 +548,7 @@ func type() {return   2 }
        gbar_kahp_slower =   0.0001
        insert cal
        gbar_cal =   0.0002
-       insert cat
+       insert traub_cat
        gbar_cat =   0.002
        insert ar
        gbar_ar =   2.5E-05

--- a/cells/suppyrFRB_template.hoc
+++ b/cells/suppyrFRB_template.hoc
@@ -424,7 +424,7 @@ func type() {return 1 }
        gbar_k2 =   0.0001
        insert kahp
        gbar_kahp =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.001
        insert traub_cat
        gbar_cat =   0.0001
@@ -453,7 +453,7 @@ func type() {return 1 }
        gbar_k2 =   0.0001
        insert kahp
        gbar_kahp =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.001
        insert traub_cat
        gbar_cat =   0.0001
@@ -482,7 +482,7 @@ func type() {return 1 }
        gbar_k2 =   0.0001
        insert kahp
        gbar_kahp =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.001
        insert traub_cat
        gbar_cat =   0.0001
@@ -511,7 +511,7 @@ func type() {return 1 }
        gbar_k2 =   0.0001
        insert kahp
        gbar_kahp =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.001
        insert traub_cat
        gbar_cat =   0.0001
@@ -540,7 +540,7 @@ func type() {return 1 }
        gbar_k2 =   0.0001
        insert kahp
        gbar_kahp =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.001
        insert traub_cat
        gbar_cat =   0.0001
@@ -569,7 +569,7 @@ func type() {return 1 }
        gbar_k2 =   0.0001
        insert kahp
        gbar_kahp =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.001
        insert traub_cat
        gbar_cat =   0.0001
@@ -598,7 +598,7 @@ func type() {return 1 }
        gbar_k2 =   0.0001
        insert kahp
        gbar_kahp =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.001
        insert traub_cat
        gbar_cat =   0.0001
@@ -627,7 +627,7 @@ func type() {return 1 }
        gbar_k2 =   0.0001
        insert kahp
        gbar_kahp =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.001
        insert traub_cat
        gbar_cat =   0.0001
@@ -656,7 +656,7 @@ func type() {return 1 }
        gbar_k2 =   0.0001
        insert kahp
        gbar_kahp =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.001
        insert traub_cat
        gbar_cat =   0.0001
@@ -685,7 +685,7 @@ func type() {return 1 }
        gbar_k2 =   0.0001
        insert kahp
        gbar_kahp =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.001
        insert traub_cat
        gbar_cat =   0.0001
@@ -714,7 +714,7 @@ func type() {return 1 }
        gbar_k2 =   0.0001
        insert kahp
        gbar_kahp =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.001
        insert traub_cat
        gbar_cat =   0.0001
@@ -743,7 +743,7 @@ func type() {return 1 }
        gbar_k2 =   0.0001
        insert kahp
        gbar_kahp =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.001
        insert traub_cat
        gbar_cat =   0.0001

--- a/cells/suppyrFRB_template.hoc
+++ b/cells/suppyrFRB_template.hoc
@@ -426,7 +426,7 @@ func type() {return 1 }
        gbar_kahp =   0.0001
        insert cal
        gbar_cal =   0.001
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.00025
@@ -455,7 +455,7 @@ func type() {return 1 }
        gbar_kahp =   0.0001
        insert cal
        gbar_cal =   0.001
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.00025
@@ -484,7 +484,7 @@ func type() {return 1 }
        gbar_kahp =   0.0001
        insert cal
        gbar_cal =   0.001
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.00025
@@ -513,7 +513,7 @@ func type() {return 1 }
        gbar_kahp =   0.0001
        insert cal
        gbar_cal =   0.001
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.00025
@@ -542,7 +542,7 @@ func type() {return 1 }
        gbar_kahp =   0.0001
        insert cal
        gbar_cal =   0.001
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.00025
@@ -571,7 +571,7 @@ func type() {return 1 }
        gbar_kahp =   0.0001
        insert cal
        gbar_cal =   0.001
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.00025
@@ -600,7 +600,7 @@ func type() {return 1 }
        gbar_kahp =   0.0001
        insert cal
        gbar_cal =   0.001
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.00025
@@ -629,7 +629,7 @@ func type() {return 1 }
        gbar_kahp =   0.0001
        insert cal
        gbar_cal =   0.001
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.00025
@@ -658,7 +658,7 @@ func type() {return 1 }
        gbar_kahp =   0.0001
        insert cal
        gbar_cal =   0.001
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.00025
@@ -687,7 +687,7 @@ func type() {return 1 }
        gbar_kahp =   0.0001
        insert cal
        gbar_cal =   0.001
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.00025
@@ -716,7 +716,7 @@ func type() {return 1 }
        gbar_kahp =   0.0001
        insert cal
        gbar_cal =   0.001
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.00025
@@ -745,7 +745,7 @@ func type() {return 1 }
        gbar_kahp =   0.0001
        insert cal
        gbar_cal =   0.001
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.00025

--- a/cells/suppyrRS_template.hoc
+++ b/cells/suppyrRS_template.hoc
@@ -431,7 +431,7 @@ func type() {return  0 }
        gbar_kahp =   0.0001
        insert cal
        gbar_cal =   0.001
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.00025
@@ -460,7 +460,7 @@ func type() {return  0 }
        gbar_kahp =   0.0001
        insert cal
        gbar_cal =   0.001
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.00025
@@ -489,7 +489,7 @@ func type() {return  0 }
        gbar_kahp =   0.0001
        insert cal
        gbar_cal =   0.001
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.00025
@@ -518,7 +518,7 @@ func type() {return  0 }
        gbar_kahp =   0.0001
        insert cal
        gbar_cal =   0.001
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.00025
@@ -547,7 +547,7 @@ func type() {return  0 }
        gbar_kahp =   0.0001
        insert cal
        gbar_cal =   0.001
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.00025
@@ -576,7 +576,7 @@ func type() {return  0 }
        gbar_kahp =   0.0001
        insert cal
        gbar_cal =   0.001
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.00025
@@ -605,7 +605,7 @@ func type() {return  0 }
        gbar_kahp =   0.0001
        insert cal
        gbar_cal =   0.001
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.00025
@@ -634,7 +634,7 @@ func type() {return  0 }
        gbar_kahp =   0.0001
        insert cal
        gbar_cal =   0.001
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.00025
@@ -663,7 +663,7 @@ func type() {return  0 }
        gbar_kahp =   0.0001
        insert cal
        gbar_cal =   0.001
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.00025
@@ -692,7 +692,7 @@ func type() {return  0 }
        gbar_kahp =   0.0001
        insert cal
        gbar_cal =   0.001
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.00025
@@ -721,7 +721,7 @@ func type() {return  0 }
        gbar_kahp =   0.0001
        insert cal
        gbar_cal =   0.001
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.00025
@@ -750,7 +750,7 @@ func type() {return  0 }
        gbar_kahp =   0.0001
        insert cal
        gbar_cal =   0.001
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.00025

--- a/cells/suppyrRS_template.hoc
+++ b/cells/suppyrRS_template.hoc
@@ -429,7 +429,7 @@ func type() {return  0 }
        gbar_k2 =   0.0001
        insert kahp
        gbar_kahp =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.001
        insert traub_cat
        gbar_cat =   0.0001
@@ -458,7 +458,7 @@ func type() {return  0 }
        gbar_k2 =   0.0001
        insert kahp
        gbar_kahp =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.001
        insert traub_cat
        gbar_cat =   0.0001
@@ -487,7 +487,7 @@ func type() {return  0 }
        gbar_k2 =   0.0001
        insert kahp
        gbar_kahp =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.001
        insert traub_cat
        gbar_cat =   0.0001
@@ -516,7 +516,7 @@ func type() {return  0 }
        gbar_k2 =   0.0001
        insert kahp
        gbar_kahp =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.001
        insert traub_cat
        gbar_cat =   0.0001
@@ -545,7 +545,7 @@ func type() {return  0 }
        gbar_k2 =   0.0001
        insert kahp
        gbar_kahp =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.001
        insert traub_cat
        gbar_cat =   0.0001
@@ -574,7 +574,7 @@ func type() {return  0 }
        gbar_k2 =   0.0001
        insert kahp
        gbar_kahp =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.001
        insert traub_cat
        gbar_cat =   0.0001
@@ -603,7 +603,7 @@ func type() {return  0 }
        gbar_k2 =   0.0001
        insert kahp
        gbar_kahp =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.001
        insert traub_cat
        gbar_cat =   0.0001
@@ -632,7 +632,7 @@ func type() {return  0 }
        gbar_k2 =   0.0001
        insert kahp
        gbar_kahp =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.001
        insert traub_cat
        gbar_cat =   0.0001
@@ -661,7 +661,7 @@ func type() {return  0 }
        gbar_k2 =   0.0001
        insert kahp
        gbar_kahp =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.001
        insert traub_cat
        gbar_cat =   0.0001
@@ -690,7 +690,7 @@ func type() {return  0 }
        gbar_k2 =   0.0001
        insert kahp
        gbar_kahp =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.001
        insert traub_cat
        gbar_cat =   0.0001
@@ -719,7 +719,7 @@ func type() {return  0 }
        gbar_k2 =   0.0001
        insert kahp
        gbar_kahp =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.001
        insert traub_cat
        gbar_cat =   0.0001
@@ -748,7 +748,7 @@ func type() {return  0 }
        gbar_k2 =   0.0001
        insert kahp
        gbar_kahp =   0.0001
-       insert cal
+       insert traub_cal
        gbar_cal =   0.001
        insert traub_cat
        gbar_cat =   0.0001

--- a/cells/tuftIB_template.hoc
+++ b/cells/tuftIB_template.hoc
@@ -437,7 +437,7 @@ func type() {return    6 }
        gbar_k2 =   0.0005
        insert kahp_deeppyr
        gbar_kahp_deeppyr =   0.0002
-       insert cal
+       insert traub_cal
        gbar_cal =   0.004
        insert traub_cat
        gbar_cat =   0.0001
@@ -466,7 +466,7 @@ func type() {return    6 }
        gbar_k2 =   0.0005
        insert kahp_deeppyr
        gbar_kahp_deeppyr =   0.0002
-       insert cal
+       insert traub_cal
        gbar_cal =   0.004
        insert traub_cat
        gbar_cat =   0.0001
@@ -493,7 +493,7 @@ func type() {return    6 }
        gbar_k2 =   0.0005
        insert kahp_deeppyr
        gbar_kahp_deeppyr =   0.0002
-       insert cal
+       insert traub_cal
        gbar_cal =   0.004
        insert traub_cat
        gbar_cat =   0.0001
@@ -520,7 +520,7 @@ func type() {return    6 }
        gbar_k2 =   0.0005
        insert kahp_deeppyr
        gbar_kahp_deeppyr =   0.0002
-       insert cal
+       insert traub_cal
        gbar_cal =   0.004
        insert traub_cat
        gbar_cat =   0.0001
@@ -549,7 +549,7 @@ func type() {return    6 }
        gbar_k2 =   0.0005
        insert kahp_deeppyr
        gbar_kahp_deeppyr =   0.0002
-       insert cal
+       insert traub_cal
        gbar_cal =   0.004
        insert traub_cat
        gbar_cat =   0.0001
@@ -578,7 +578,7 @@ func type() {return    6 }
        gbar_k2 =   0.0005
        insert kahp_deeppyr
        gbar_kahp_deeppyr =   0.0002
-       insert cal
+       insert traub_cal
        gbar_cal =   0.004
        insert traub_cat
        gbar_cat =   0.0001
@@ -605,7 +605,7 @@ func type() {return    6 }
        gbar_k2 =   0.0005
        insert kahp_deeppyr
        gbar_kahp_deeppyr =   0.0002
-       insert cal
+       insert traub_cal
        gbar_cal =   0.004
        insert traub_cat
        gbar_cat =   0.0001
@@ -632,7 +632,7 @@ func type() {return    6 }
        gbar_k2 =   0.0005
        insert kahp_deeppyr
        gbar_kahp_deeppyr =   0.0002
-       insert cal
+       insert traub_cal
        gbar_cal =   0.001
        insert traub_cat
        gbar_cat =   0.0001
@@ -659,7 +659,7 @@ func type() {return    6 }
        gbar_k2 =   0.0005
        insert kahp_deeppyr
        gbar_kahp_deeppyr =   0.0002
-       insert cal
+       insert traub_cal
        gbar_cal =   0.001
        insert traub_cat
        gbar_cat =   0.0001
@@ -686,7 +686,7 @@ func type() {return    6 }
        gbar_k2 =   0.0005
        insert kahp_deeppyr
        gbar_kahp_deeppyr =   0.0002
-       insert cal
+       insert traub_cal
        gbar_cal =   0.001
        insert traub_cat
        gbar_cat =   0.0001
@@ -713,7 +713,7 @@ func type() {return    6 }
        gbar_k2 =   0.0005
        insert kahp_deeppyr
        gbar_kahp_deeppyr =   0.0002
-       insert cal
+       insert traub_cal
        gbar_cal =   0.001
        insert traub_cat
        gbar_cat =   0.0001
@@ -740,7 +740,7 @@ func type() {return    6 }
        gbar_k2 =   0.0005
        insert kahp_deeppyr
        gbar_kahp_deeppyr =   0.0002
-       insert cal
+       insert traub_cal
        gbar_cal =   0.001
        insert traub_cat
        gbar_cat =   0.0001
@@ -767,7 +767,7 @@ func type() {return    6 }
        gbar_k2 =   0.0005
        insert kahp_deeppyr
        gbar_kahp_deeppyr =   0.0002
-       insert cal
+       insert traub_cal
        gbar_cal =   0.001
        insert traub_cat
        gbar_cat =   0.0001
@@ -794,7 +794,7 @@ func type() {return    6 }
        gbar_k2 =   0.0005
        insert kahp_deeppyr
        gbar_kahp_deeppyr =   0.0002
-       insert cal
+       insert traub_cal
        gbar_cal =   0.001
        insert traub_cat
        gbar_cat =   0.0001
@@ -821,7 +821,7 @@ func type() {return    6 }
        gbar_k2 =   0.0005
        insert kahp_deeppyr
        gbar_kahp_deeppyr =   0.0002
-       insert cal
+       insert traub_cal
        gbar_cal =   0.001
        insert traub_cat
        gbar_cat =   0.0001
@@ -848,7 +848,7 @@ func type() {return    6 }
        gbar_k2 =   0.0005
        insert kahp_deeppyr
        gbar_kahp_deeppyr =   0.0002
-       insert cal
+       insert traub_cal
        gbar_cal =   0.001
        insert traub_cat
        gbar_cat =   0.0001
@@ -875,7 +875,7 @@ func type() {return    6 }
        gbar_k2 =   0.0005
        insert kahp_deeppyr
        gbar_kahp_deeppyr =   0.0002
-       insert cal
+       insert traub_cal
        gbar_cal =   0.001
        insert traub_cat
        gbar_cat =   0.0001
@@ -902,7 +902,7 @@ func type() {return    6 }
        gbar_k2 =   0.0005
        insert kahp_deeppyr
        gbar_kahp_deeppyr =   0.0002
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0006
        insert traub_cat
        gbar_cat =   0.0001

--- a/cells/tuftIB_template.hoc
+++ b/cells/tuftIB_template.hoc
@@ -439,7 +439,7 @@ func type() {return    6 }
        gbar_kahp_deeppyr =   0.0002
        insert cal
        gbar_cal =   0.004
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.0001
@@ -468,7 +468,7 @@ func type() {return    6 }
        gbar_kahp_deeppyr =   0.0002
        insert cal
        gbar_cal =   0.004
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.0001
@@ -495,7 +495,7 @@ func type() {return    6 }
        gbar_kahp_deeppyr =   0.0002
        insert cal
        gbar_cal =   0.004
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.0001
@@ -522,7 +522,7 @@ func type() {return    6 }
        gbar_kahp_deeppyr =   0.0002
        insert cal
        gbar_cal =   0.004
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.0001
@@ -551,7 +551,7 @@ func type() {return    6 }
        gbar_kahp_deeppyr =   0.0002
        insert cal
        gbar_cal =   0.004
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.0001
@@ -580,7 +580,7 @@ func type() {return    6 }
        gbar_kahp_deeppyr =   0.0002
        insert cal
        gbar_cal =   0.004
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.0001
@@ -607,7 +607,7 @@ func type() {return    6 }
        gbar_kahp_deeppyr =   0.0002
        insert cal
        gbar_cal =   0.004
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.0001
@@ -634,7 +634,7 @@ func type() {return    6 }
        gbar_kahp_deeppyr =   0.0002
        insert cal
        gbar_cal =   0.001
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.0001
@@ -661,7 +661,7 @@ func type() {return    6 }
        gbar_kahp_deeppyr =   0.0002
        insert cal
        gbar_cal =   0.001
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.0001
@@ -688,7 +688,7 @@ func type() {return    6 }
        gbar_kahp_deeppyr =   0.0002
        insert cal
        gbar_cal =   0.001
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.0001
@@ -715,7 +715,7 @@ func type() {return    6 }
        gbar_kahp_deeppyr =   0.0002
        insert cal
        gbar_cal =   0.001
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.0001
@@ -742,7 +742,7 @@ func type() {return    6 }
        gbar_kahp_deeppyr =   0.0002
        insert cal
        gbar_cal =   0.001
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.0001
@@ -769,7 +769,7 @@ func type() {return    6 }
        gbar_kahp_deeppyr =   0.0002
        insert cal
        gbar_cal =   0.001
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.0001
@@ -796,7 +796,7 @@ func type() {return    6 }
        gbar_kahp_deeppyr =   0.0002
        insert cal
        gbar_cal =   0.001
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.0001
@@ -823,7 +823,7 @@ func type() {return    6 }
        gbar_kahp_deeppyr =   0.0002
        insert cal
        gbar_cal =   0.001
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.0001
@@ -850,7 +850,7 @@ func type() {return    6 }
        gbar_kahp_deeppyr =   0.0002
        insert cal
        gbar_cal =   0.001
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.0001
@@ -877,7 +877,7 @@ func type() {return    6 }
        gbar_kahp_deeppyr =   0.0002
        insert cal
        gbar_cal =   0.001
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.0001
@@ -904,7 +904,7 @@ func type() {return    6 }
        gbar_kahp_deeppyr =   0.0002
        insert cal
        gbar_cal =   0.0006
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.0002

--- a/cells/tuftRS_template.hoc
+++ b/cells/tuftRS_template.hoc
@@ -376,7 +376,7 @@ func type() {return    7 }
        gbar_k2 =   0.0005
        insert kahp_deeppyr
        gbar_kahp_deeppyr =   0.0002
-       insert cal
+       insert traub_cal
        gbar_cal =   0.004
        insert traub_cat
        gbar_cat =   0.0001
@@ -405,7 +405,7 @@ func type() {return    7 }
        gbar_k2 =   0.0005
        insert kahp_deeppyr
        gbar_kahp_deeppyr =   0.0002
-       insert cal
+       insert traub_cal
        gbar_cal =   0.004
        insert traub_cat
        gbar_cat =   0.0001
@@ -432,7 +432,7 @@ func type() {return    7 }
        gbar_k2 =   0.0005
        insert kahp_deeppyr
        gbar_kahp_deeppyr =   0.0002
-       insert cal
+       insert traub_cal
        gbar_cal =   0.004
        insert traub_cat
        gbar_cat =   0.0001
@@ -459,7 +459,7 @@ func type() {return    7 }
        gbar_k2 =   0.0005
        insert kahp_deeppyr
        gbar_kahp_deeppyr =   0.0002
-       insert cal
+       insert traub_cal
        gbar_cal =   0.004
        insert traub_cat
        gbar_cat =   0.0001
@@ -488,7 +488,7 @@ func type() {return    7 }
        gbar_k2 =   0.0005
        insert kahp_deeppyr
        gbar_kahp_deeppyr =   0.0002
-       insert cal
+       insert traub_cal
        gbar_cal =   0.004
        insert traub_cat
        gbar_cat =   0.0001
@@ -517,7 +517,7 @@ func type() {return    7 }
        gbar_k2 =   0.0005
        insert kahp_deeppyr
        gbar_kahp_deeppyr =   0.0002
-       insert cal
+       insert traub_cal
        gbar_cal =   0.004
        insert traub_cat
        gbar_cat =   0.0001
@@ -544,7 +544,7 @@ func type() {return    7 }
        gbar_k2 =   0.0005
        insert kahp_deeppyr
        gbar_kahp_deeppyr =   0.0002
-       insert cal
+       insert traub_cal
        gbar_cal =   0.004
        insert traub_cat
        gbar_cat =   0.0001
@@ -571,7 +571,7 @@ func type() {return    7 }
        gbar_k2 =   0.0005
        insert kahp_deeppyr
        gbar_kahp_deeppyr =   0.0002
-       insert cal
+       insert traub_cal
        gbar_cal =   0.001
        insert traub_cat
        gbar_cat =   0.0001
@@ -598,7 +598,7 @@ func type() {return    7 }
        gbar_k2 =   0.0005
        insert kahp_deeppyr
        gbar_kahp_deeppyr =   0.0002
-       insert cal
+       insert traub_cal
        gbar_cal =   0.001
        insert traub_cat
        gbar_cat =   0.0001
@@ -625,7 +625,7 @@ func type() {return    7 }
        gbar_k2 =   0.0005
        insert kahp_deeppyr
        gbar_kahp_deeppyr =   0.0002
-       insert cal
+       insert traub_cal
        gbar_cal =   0.001
        insert traub_cat
        gbar_cat =   0.0001
@@ -652,7 +652,7 @@ func type() {return    7 }
        gbar_k2 =   0.0005
        insert kahp_deeppyr
        gbar_kahp_deeppyr =   0.0002
-       insert cal
+       insert traub_cal
        gbar_cal =   0.001
        insert traub_cat
        gbar_cat =   0.0001
@@ -679,7 +679,7 @@ func type() {return    7 }
        gbar_k2 =   0.0005
        insert kahp_deeppyr
        gbar_kahp_deeppyr =   0.0002
-       insert cal
+       insert traub_cal
        gbar_cal =   0.001
        insert traub_cat
        gbar_cat =   0.0001
@@ -706,7 +706,7 @@ func type() {return    7 }
        gbar_k2 =   0.0005
        insert kahp_deeppyr
        gbar_kahp_deeppyr =   0.0002
-       insert cal
+       insert traub_cal
        gbar_cal =   0.001
        insert traub_cat
        gbar_cat =   0.0001
@@ -733,7 +733,7 @@ func type() {return    7 }
        gbar_k2 =   0.0005
        insert kahp_deeppyr
        gbar_kahp_deeppyr =   0.0002
-       insert cal
+       insert traub_cal
        gbar_cal =   0.001
        insert traub_cat
        gbar_cat =   0.0001
@@ -760,7 +760,7 @@ func type() {return    7 }
        gbar_k2 =   0.0005
        insert kahp_deeppyr
        gbar_kahp_deeppyr =   0.0002
-       insert cal
+       insert traub_cal
        gbar_cal =   0.001
        insert traub_cat
        gbar_cat =   0.0001
@@ -787,7 +787,7 @@ func type() {return    7 }
        gbar_k2 =   0.0005
        insert kahp_deeppyr
        gbar_kahp_deeppyr =   0.0002
-       insert cal
+       insert traub_cal
        gbar_cal =   0.001
        insert traub_cat
        gbar_cat =   0.0001
@@ -814,7 +814,7 @@ func type() {return    7 }
        gbar_k2 =   0.0005
        insert kahp_deeppyr
        gbar_kahp_deeppyr =   0.0002
-       insert cal
+       insert traub_cal
        gbar_cal =   0.001
        insert traub_cat
        gbar_cat =   0.0001
@@ -841,7 +841,7 @@ func type() {return    7 }
        gbar_k2 =   0.0005
        insert kahp_deeppyr
        gbar_kahp_deeppyr =   0.0002
-       insert cal
+       insert traub_cal
        gbar_cal =   0.0006
        insert traub_cat
        gbar_cat =   0.0001

--- a/cells/tuftRS_template.hoc
+++ b/cells/tuftRS_template.hoc
@@ -378,7 +378,7 @@ func type() {return    7 }
        gbar_kahp_deeppyr =   0.0002
        insert cal
        gbar_cal =   0.004
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.0001
@@ -407,7 +407,7 @@ func type() {return    7 }
        gbar_kahp_deeppyr =   0.0002
        insert cal
        gbar_cal =   0.004
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.0001
@@ -434,7 +434,7 @@ func type() {return    7 }
        gbar_kahp_deeppyr =   0.0002
        insert cal
        gbar_cal =   0.004
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.0001
@@ -461,7 +461,7 @@ func type() {return    7 }
        gbar_kahp_deeppyr =   0.0002
        insert cal
        gbar_cal =   0.004
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.0001
@@ -490,7 +490,7 @@ func type() {return    7 }
        gbar_kahp_deeppyr =   0.0002
        insert cal
        gbar_cal =   0.004
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.0001
@@ -519,7 +519,7 @@ func type() {return    7 }
        gbar_kahp_deeppyr =   0.0002
        insert cal
        gbar_cal =   0.004
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.0001
@@ -546,7 +546,7 @@ func type() {return    7 }
        gbar_kahp_deeppyr =   0.0002
        insert cal
        gbar_cal =   0.004
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.0001
@@ -573,7 +573,7 @@ func type() {return    7 }
        gbar_kahp_deeppyr =   0.0002
        insert cal
        gbar_cal =   0.001
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.0001
@@ -600,7 +600,7 @@ func type() {return    7 }
        gbar_kahp_deeppyr =   0.0002
        insert cal
        gbar_cal =   0.001
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.0001
@@ -627,7 +627,7 @@ func type() {return    7 }
        gbar_kahp_deeppyr =   0.0002
        insert cal
        gbar_cal =   0.001
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.0001
@@ -654,7 +654,7 @@ func type() {return    7 }
        gbar_kahp_deeppyr =   0.0002
        insert cal
        gbar_cal =   0.001
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.0001
@@ -681,7 +681,7 @@ func type() {return    7 }
        gbar_kahp_deeppyr =   0.0002
        insert cal
        gbar_cal =   0.001
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.0001
@@ -708,7 +708,7 @@ func type() {return    7 }
        gbar_kahp_deeppyr =   0.0002
        insert cal
        gbar_cal =   0.001
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.0001
@@ -735,7 +735,7 @@ func type() {return    7 }
        gbar_kahp_deeppyr =   0.0002
        insert cal
        gbar_cal =   0.001
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.0001
@@ -762,7 +762,7 @@ func type() {return    7 }
        gbar_kahp_deeppyr =   0.0002
        insert cal
        gbar_cal =   0.001
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.0001
@@ -789,7 +789,7 @@ func type() {return    7 }
        gbar_kahp_deeppyr =   0.0002
        insert cal
        gbar_cal =   0.001
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.0001
@@ -816,7 +816,7 @@ func type() {return    7 }
        gbar_kahp_deeppyr =   0.0002
        insert cal
        gbar_cal =   0.001
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.0001
@@ -843,7 +843,7 @@ func type() {return    7 }
        gbar_kahp_deeppyr =   0.0002
        insert cal
        gbar_cal =   0.0006
-       insert cat
+       insert traub_cat
        gbar_cat =   0.0001
        insert ar
        gbar_ar =   0.0002

--- a/commonutils.py
+++ b/commonutils.py
@@ -1,0 +1,12 @@
+import errno
+import os
+
+
+def mkdir_p(path):
+    try:
+        os.makedirs(path)
+    except OSError as exc:    # Python >2.5
+        if exc.errno == errno.EEXIST and os.path.isdir(path):
+            pass
+        else:
+            raise

--- a/hoc/parlib.hoc
+++ b/hoc/parlib.hoc
@@ -175,7 +175,7 @@ proc prun() {
         runtime=startsw()
         tdat_.x[0] = pnm.pc.wait_time
         stdinit()
-pc.nrnbbcore_write("coredat")
+pc.nrnbbcore_write(coredat)
 	if (savestatetest == 1) {
 		pnm.psolve(tstop/2)
 		savestate()

--- a/hoc/parlib.hoc
+++ b/hoc/parlib.hoc
@@ -175,7 +175,7 @@ proc prun() {
         runtime=startsw()
         tdat_.x[0] = pnm.pc.wait_time
         stdinit()
-pc.nrnbbcore_write(coredat)
+pc.nrnbbcore_write("coredat")
 	if (savestatetest == 1) {
 		pnm.psolve(tstop/2)
 		savestate()

--- a/mod/cal.mod
+++ b/mod/cal.mod
@@ -13,7 +13,7 @@ UNITS {
 }
  
 NEURON { 
-	SUFFIX cal
+	SUFFIX traub_cal
 	USEION ca WRITE ica
 	RANGE  gbar, ica
 	RANGE alpha, beta : added to write rates for comparison with F

--- a/mod/cat.mod
+++ b/mod/cat.mod
@@ -14,7 +14,7 @@ UNITS {
 }
  
 NEURON { 
-	SUFFIX cat
+    SUFFIX traub_cat
 	NONSPECIFIC_CURRENT i   : not causing [Ca2+] influx
 	RANGE gbar, i, m, h, alphah, betah 	: m,h, alphah, betah for comparison with FORTRAN
 }

--- a/notes
+++ b/notes
@@ -21,10 +21,11 @@ rather:
 corenrnbuild -m modcore -s $HOME/bb/coreneuron -i $HOME/bb/install -b buildgpu
 
 nrnivmodl mod
+export HOC_LIBRARY_PATH=`pwd`/hoc
 nrniv -c mytstop=100 temp.hoc
 
 #with command line options
-mpirun -n 3 ./x86_64/special -c mytstop=1 -c "strdef coredat"  -c coredat="\"/Users/kumbhar/Downloads/coredat1\"" temp.hoc  -mpi
+mpirun -n 3 ./x86_64/special -c mytstop=1 temp.hoc  -mpi
 
 mpirun -n 1 coreneuron_exec -mpi -d coredat --gpu -e 100 --voltage=1000 --cell_permute=2 --nwarp=10
 #mpirun is needed to get solve time

--- a/notes
+++ b/notes
@@ -23,6 +23,9 @@ corenrnbuild -m modcore -s $HOME/bb/coreneuron -i $HOME/bb/install -b buildgpu
 nrnivmodl mod
 nrniv -c mytstop=100 temp.hoc
 
+#with command line options
+mpirun -n 3 ./x86_64/special -c mytstop=1 -c "strdef coredat"  -c coredat="\"/Users/kumbhar/Downloads/coredat1\"" temp.hoc  -mpi
+
 mpirun -n 1 coreneuron_exec -mpi -d coredat --gpu -e 100 --voltage=1000 --cell_permute=2 --nwarp=10
 #mpirun is needed to get solve time
 

--- a/temp.hoc
+++ b/temp.hoc
@@ -39,7 +39,6 @@ default_var("selfevents", 0)
 
 default_var("fakerank", -1)
 default_var("fakenhost", -1)
-default_var("coredat", "coredat")
 
 gfac_AMPA = 1
 gfac_NMDA = 1
@@ -49,7 +48,7 @@ gfac_GABAA = 1
 {
     strdef cmd
     nrnpython("from commonutils import mkdir_p")
-    sprint(cmd, "mkdir_p('%s')", coredat)
+    sprint(cmd, "mkdir_p('%s')", "coredat")
     nrnpython(cmd)
 }
 

--- a/temp.hoc
+++ b/temp.hoc
@@ -1,5 +1,5 @@
 setuptime = startsw()
-{xopen("hoc/defvar.hoc")}
+{load_file("defvar.hoc")}
 
 // load balancing implies several runs.
 // 0) load balancing just plain off (but will read mcomplex.dat if exists)
@@ -55,7 +55,7 @@ gfac_GABAA = 1
 
 use_p2c_net_connections = 0 // not 0, requires p2c emitted  map and compmap files
 
-{localloadfile("manage_setup.hoc")}
+{load_file("manage_setup.hoc")}
 
 steps_per_ms = 40
 dt = .025

--- a/temp.hoc
+++ b/temp.hoc
@@ -39,10 +39,19 @@ default_var("selfevents", 0)
 
 default_var("fakerank", -1)
 default_var("fakenhost", -1)
+default_var("coredat", "coredat")
 
 gfac_AMPA = 1
 gfac_NMDA = 1
 gfac_GABAA = 1
+
+// create directory for writing dataset
+{
+    strdef cmd
+    nrnpython("from commonutils import mkdir_p")
+    sprint(cmd, "mkdir_p('%s')", coredat)
+    nrnpython(cmd)
+}
 
 use_p2c_net_connections = 0 // not 0, requires p2c emitted  map and compmap files
 

--- a/vclampg.hoc
+++ b/vclampg.hoc
@@ -44,7 +44,7 @@ proc vclampg() { local i, j, y, numcomp  localobj vv, f, s, clist, c, rsav, cdvd
 	rsav = new Vector()
 	for i=1, vmat.ncol-1 cell.comp[i] {
 		rsav.append(Ra)
-		insert cal  insert ar  insert cat_a
+		insert traub_cal  insert ar  insert cat_a
 		Ra = 1e9
 		c = new SEClamp(.5)
 		c.dur1 = 1e9


### PR DESCRIPTION
@nrnhines : while benchmarking with `5` different models with `neuron` and `coreneuron`, I wanted to build `single` executable i.e. `special` (from `NEURON` side). But two `mod` files had `same` `SUFFIX` (in neurodamus and this traub model). So I decided to change `SUFFIX` for below two mod files and hence you see lot of changes here.

* Is this fine?

I changed `xopen` and `loadlocalfile` as I wanted to run simulation from different directories with one copy of `HOC_LIBRARY_PATH`. From my understanding, `xopen` and `loadlocalfile` needs `absolute` path.